### PR TITLE
Add support for lists in versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pycharm
+.idea

--- a/pin_poetry_dependencies/__init__.py
+++ b/pin_poetry_dependencies/__init__.py
@@ -26,6 +26,10 @@ def iter_dependencies(obj: Mapping[Any, Any]):
     for dep, version in obj["tool"]["poetry"]["dependencies"].items():
         if isinstance(version, str):
             yield dep, version
+        elif isinstance(version, list):
+            for version_mapping in version:
+                if "version" in version_mapping:
+                    yield dep, version_mapping["version"]
         elif isinstance(version, Mapping):
             if "version" in version:
                 yield dep, version["version"]

--- a/tests/iter_dependencies_test.py
+++ b/tests/iter_dependencies_test.py
@@ -21,6 +21,8 @@ def test_iter_dependencies() -> None:
     assert list(dependencies) == [
         ("requests", "^2.25.1"),
         ("toml", "^0.10.2"),
+        ("torch", "^2.2.2"),
+        ("torch", "^2.2.2+cpu"),
     ]
 
 def test_iter_dependencies_no_dependencies() -> None:

--- a/tests/iter_dependencies_test.py
+++ b/tests/iter_dependencies_test.py
@@ -10,6 +10,10 @@ def test_iter_dependencies() -> None:
                 "dependencies": {
                     "requests": "^2.25.1",
                     "toml": {"version": "^0.10.2"},
+                    "torch": [
+                        {"version": "^2.2.2"},
+                        {"version": "^2.2.2+cpu"},
+                    ],
                 }
             }
         }

--- a/tests/iter_dependencies_test.py
+++ b/tests/iter_dependencies_test.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pin_poetry_dependencies import iter_dependencies
+
+
+def test_iter_dependencies() -> None:
+    dependencies = iter_dependencies({
+        "tool": {
+            "poetry": {
+                "dependencies": {
+                    "requests": "^2.25.1",
+                    "toml": {"version": "^0.10.2"},
+                }
+            }
+        }
+    })
+    assert list(dependencies) == [
+        ("requests", "^2.25.1"),
+        ("toml", "^0.10.2"),
+    ]
+
+def test_iter_dependencies_no_dependencies() -> None:
+    with pytest.raises(ValueError, match="No dependencies found"):
+        list(iter_dependencies({}))
+
+def test_iter_dependencies_unexpected_version_type() -> None:
+    with pytest.raises(ValueError, match="Unexpected version type: <class 'int'>"):
+        list(iter_dependencies({
+            "tool": {
+                "poetry": {
+                    "dependencies": {
+                        "requests": 42,
+                    }
+                }
+            }
+        })
+    )


### PR DESCRIPTION
Poetry supports lists in versions, my usecase is for picking different version of torch in linux vs macos. Added support for it with some extra tests